### PR TITLE
Update installation instructions to account for OPAM install

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,12 @@ following to your `.emacs` file:
     (when (not (= (length stdoutput) 0))
       stdoutput)))
 
-(let* ((refmt-bin (shell-cmd "refmt ----where"))
-       (merlin-bin (shell-cmd "ocamlmerlin ----where"))
-       (merlin-base-dir (when merlin-bin (replace-regexp-in-string "bin/ocamlmerlin$" "" merlin-bin))))
+(let* ((refmt-bin (or (shell-cmd "refmt ----where")
+                      (shell-cmd "which refmt")))
+       (merlin-bin (or (shell-cmd "ocamlmerlin ----where")
+                       (shell-cmd "which ocamlmerlin")))
+       (merlin-base-dir (when merlin-bin
+                          (replace-regexp-in-string "bin/ocamlmerlin$" "" merlin-bin))))
   ;; Add npm merlin.el to the emacs load path and tell emacs where to find ocamlmerlin
   (when merlin-bin
     (add-to-list 'load-path (concat merlin-base-dir "share/emacs/site-lisp/"))


### PR DESCRIPTION
These instructions will now work if you have Reason / Merlin installed via either OPAM or ReasonCLI