### PR TITLE
Improve Jsx indentation

### DIFF
--- a/reason-indent.el
+++ b/reason-indent.el
@@ -168,7 +168,6 @@ This is written mainly to be used as `end-of-defun-function' for Reason."
                            (progn
                              (unless (and (looking-at "[[:space:]\n]*<")
                                           (reason-looking-back-str "=>"))
-                               (message "backward-up-list")
                                (backward-up-list))
                              (reason-rewind-to-beginning-of-current-level-expr)
 
@@ -184,7 +183,6 @@ This is written mainly to be used as `end-of-defun-function' for Reason."
 
                               ((looking-at "[[:word:]]+:.*=> ?{?$")
                                (looking-at "[[:word:]]+:.*=> ?{?$")
-                               (message "foobar")
                                (+ (current-column) reason-indent-offset))
 
                               (t

--- a/reason-indent.el
+++ b/reason-indent.el
@@ -150,15 +150,26 @@ This is written mainly to be used as `end-of-defun-function' for Reason."
                    (if (= 0 level)
                        0
                      (save-excursion
+                       ;; jsx, end of previous tag
                        (reason-rewind-irrelevant)
                        (if (save-excursion
                              (reason-rewind-to-beginning-of-current-level-expr)
-                             (looking-at "<"))
+                             ;; beginning of previous tag
+                             (looking-at "\\(<\\|\\.\\.\\.\\)"))
                            (progn
                              (reason-rewind-to-beginning-of-current-level-expr)
-                             (current-column))
+                             ;; beginning of previous tag
+                             (cond
+                              ((looking-at ".*\\(<.*/>\\|</.*>\\)") ;; (self) closing tag
+                               (current-column))
+                              ((looking-at "<")
+                               (+ (current-column) reason-indent-offset))
+                              (t (current-column))))
                            (progn
-                             (backward-up-list)
+                             (unless (and (looking-at "[[:space:]\n]*<")
+                                          (reason-looking-back-str "=>"))
+                               (message "backward-up-list")
+                               (backward-up-list))
                              (reason-rewind-to-beginning-of-current-level-expr)
 
                              (cond
@@ -170,6 +181,11 @@ This is written mainly to be used as `end-of-defun-function' for Reason."
 
                               ((looking-at "|")
                                (+ (current-column) (* reason-indent-offset 2)))
+
+                              ((looking-at "[[:word:]]+:.*=> ?{?$")
+                               (looking-at "[[:word:]]+:.*=> ?{?$")
+                               (message "foobar")
+                               (+ (current-column) reason-indent-offset))
 
                               (t
                                (let ((current-level (reason-paren-level)))
@@ -202,6 +218,9 @@ This is written mainly to be used as `end-of-defun-function' for Reason."
                 (t (+ baseline (+ reason-indent-offset 1)))))
 
               ((looking-at "</") (- baseline reason-indent-offset))
+              ((looking-at "<") baseline)
+              ((looking-at "<.*/>") baseline)
+              ((looking-at "\\.\\.\\.") baseline)
 
               ;; A closing brace is 1 level unindented
               ((looking-at "}\\|)\\|\\]")

--- a/reason-indent.el
+++ b/reason-indent.el
@@ -165,6 +165,9 @@ This is written mainly to be used as `end-of-defun-function' for Reason."
                               ((looking-at "switch")
                                (current-column))
 
+                              (looking-at "if")
+                               (+ (current-column) reason-indent-offset)))
+
                               ((looking-at "|")
                                (+ (current-column) (* reason-indent-offset 2)))
 

--- a/reason-indent.el
+++ b/reason-indent.el
@@ -165,8 +165,8 @@ This is written mainly to be used as `end-of-defun-function' for Reason."
                               ((looking-at "switch")
                                (current-column))
 
-                              (looking-at "if")
-                               (+ (current-column) reason-indent-offset)))
+                              ((looking-at "if")
+                               (+ (current-column) reason-indent-offset))
 
                               ((looking-at "|")
                                (+ (current-column) (* reason-indent-offset 2)))

--- a/reason-indent.el
+++ b/reason-indent.el
@@ -182,7 +182,6 @@ This is written mainly to be used as `end-of-defun-function' for Reason."
                                (+ (current-column) (* reason-indent-offset 2)))
 
                               ((looking-at "[[:word:]]+:.*=> ?{?$")
-                               (looking-at "[[:word:]]+:.*=> ?{?$")
                                (+ (current-column) reason-indent-offset))
 
                               (t

--- a/test/reason-test.el
+++ b/test/reason-test.el
@@ -216,6 +216,17 @@ fun foo() => {
 };
 "))
 
+(ert-deftest indent-if ()
+  (test-indent
+   "
+fun foo() => {
+  if (blah) {
+    stuff
+  } else {
+    otherStuff
+  }
+}"))
+
 (ert-deftest indent-switch-multiline-pattern ()
   (test-indent
    "

--- a/test/reason-test.el
+++ b/test/reason-test.el
@@ -377,6 +377,21 @@ let make = (_children) => {
 };
 "))
 
+(ert-deftest indent-jsx-4 ()
+  (test-indent
+   "
+let make = (name, children) => {
+  ...component,
+  render: self =>
+    <View>
+      <Text value=name />
+      <View>
+        ...children
+      </View>
+    </View>
+};
+"))
+
 (defun reason-get-buffer-pos (pos-symbol)
   "Get buffer position from POS-SYMBOL.
 

--- a/test/reason-test.el
+++ b/test/reason-test.el
@@ -374,7 +374,7 @@ let make = (_children) => {
       </View>
     </View>
   }
-}
+};
 "))
 
 (defun reason-get-buffer-pos (pos-symbol)

--- a/test/reason-test.el
+++ b/test/reason-test.el
@@ -270,6 +270,28 @@ fun foo() => {
 };
 "))
 
+(ert-deftest indent-indented-object-func ()
+  (test-indent
+"
+module MyApp = {
+  type state = {db:db};
+  type action = Click;
+  let component = ReasonReact.reducerComponent(\"MyApp\");
+  let make = (_children) => {
+    ...component,
+    initialState: () => {db:[||]},
+    reducer: (a: action, s:state) =>
+      switch(a) {
+      | Click => ReasonReact.Update(s)
+      },
+    render: _self => {
+      let a = 20;
+      <Text value=\"foo\" />
+    }
+  }
+};
+"))
+
 (ert-deftest indented-multi-expr-switch ()
   (test-indent
    "
@@ -335,6 +357,24 @@ let make keyInfo::k=? _children => {
       </div>
     </div>
 };
+"))
+
+(ert-deftest indent-jsx-3 ()
+  (test-indent
+   "
+let make = (_children) => {
+  ...component,
+  render: self => {
+    let name = \"foo\";
+    let children = List.map(el => <Text value=el />, [\"foo\", \"bar\"]);
+    <View>
+      <Text value=name />
+      <View>
+        ...children
+      </View>
+    </View>
+  }
+}
 "))
 
 (defun reason-get-buffer-pos (pos-symbol)


### PR DESCRIPTION
I noticed some simple jsx patterns were not indented correctly.
I added 2 tests to illustrate the failing patterns.
The fix is not the best, it's based on some ugly heuristics on xml coding style.