### PR TITLE
Allow using refmt from the current opam switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ If you have iedit mode set up:
 
 This associates `reason-mode` with `.re` and `.rei` files. To enable it explicitly, do <kbd>M-x reason-mode</kbd>.
 
+### Project specific version of `refmt`
+
+If you're using different versions of `refmt` between projects, you can use the project-specific installed version via the special config values:
+- `'npm` (calls `npx refmt ...` to use the version of `refmt` installed in the project's `node_modules`) 
+- `'opam` (calls `opam exec -- refmt ...` to use the version of `refmt` on the current `opam` switch):
+
+```lisp
+;; can also be set via M-x `customize-mode`
+(setq refmt-command 'npm)
+```
+
 ### Utop
 
 Reason-mode provides (opt-in) `rtop` support. At the moment only the native workflow is supported.

--- a/refmt.el
+++ b/refmt.el
@@ -39,7 +39,8 @@
 (defcustom refmt-command "refmt"
   "The 'refmt' command."
   :type '(choice (file :tag "Filename (default binary is \"refmt\")")
-                 (const :tag "Use current opam switch" opam))
+                 (const :tag "Use current opam switch" opam)
+                 (const :tag "Use current npm version (via npx)" npm))
   :group 're-fmt)
 
 (defcustom refmt-show-errors 'buffer
@@ -199,11 +200,17 @@ function."
              (erase-buffer))
            (if (zerop (let* ((files (list (list :file outputfile) errorfile))
                              (args (append width-args (list "--parse" from "--print" to bufferfile))))
-                        (if (equal refmt-command 'opam)
-                            (apply 'call-process
-                                   "opam" nil files nil (append '("exec" "--" "refmt") args))
-                          (apply 'call-process
-                                 refmt-command nil files nil args))))
+                        (cond ((equal refmt-command 'opam)
+                               (apply 'call-process
+                                      "opam" nil files nil (append '("exec" "--" "refmt") args)))
+
+                              ((equal refmt-command 'npm)
+                               (apply 'call-process
+                                      "npx" nil files nil (append '("refmt") args)))
+
+                              (t
+                               (apply 'call-process
+                                      refmt-command nil files nil args)))))
                (progn
                  (call-process-region start end "diff" nil patchbuf nil "-n" "-"
                                       outputfile)


### PR DESCRIPTION
Allows you to set `refmt-command` to `'opam` which will run `refmt` via `opam exec` in order to use the version on the current opam switch, inspired by a similar option in the `merlin` package.