### PR TITLE
enable .res with reason-mode

### DIFF
--- a/reason-mode.el
+++ b/reason-mode.el
@@ -233,7 +233,7 @@ Argument END marks the end of the function."
   (setq-local parse-sexp-lookup-properties t))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.rei?\\'" . reason-mode))
+(add-to-list 'auto-mode-alist '("\\.\\(res\\||rei?\\)\\'" . reason-mode))
 
 (defun reason-mode-reload ()
   "Reload Reason mode."


### PR DESCRIPTION
## Description

It will enable reason-mode to `.res` for the new ReScript.