### PR TITLE
Fixed handling of | in mutually recursive types.

### DIFF
--- a/reason-indent.el
+++ b/reason-indent.el
@@ -262,7 +262,7 @@ This is written mainly to be used as `end-of-defun-function' for Reason."
                            (while (looking-at "|")
                              (reason-rewind-irrelevant)
                              (back-to-indentation))
-                           (looking-at (regexp-opt '("type"))))
+                           (looking-at (regexp-opt '("and" "type"))))
                          (+ baseline reason-indent-offset))
                         ((looking-at "|\\|/[/*]")
                          baseline)


### PR DESCRIPTION
I haven't deeply investigated this fix but it seems to work fine. Here is the sample code I was testing it on.

```
  type rec state =
    | View(val)
    | Edit(val)
    | Actions(array<action>)
  and action =
    | Action(descriptor, state)
  and actions = array<action>;

```